### PR TITLE
Fix docs and build, rename to sf3convert

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -11,7 +11,7 @@
 #  the file LICENSE.GPL
 #=============================================================================
 
-project(sfconvert)
+project(sf3convert)
 CMAKE_MINIMUM_REQUIRED(VERSION 2.6.0)
 include (GNUInstallDirs)
 include (${PROJECT_SOURCE_DIR}/build/FindQt5.cmake)
@@ -35,7 +35,7 @@ add_executable(sf3convert
    )
 
 if (MINGW)
-   target_link_libraries(sfconvert
+   target_link_libraries(sf3convert
       ${QT_LIBRARIES}
       vorbis
       ##vorbisfile
@@ -43,7 +43,7 @@ if (MINGW)
       sndfile-1
    )
 
-   install( TARGETS sfconvert RUNTIME DESTINATION . )
+   install( TARGETS sf3convert RUNTIME DESTINATION . )
 
    install_files ( . .dll
       ${CROSS}/bin/libgcc_s_dw2-1.dll

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -13,6 +13,7 @@
 
 project(sfconvert)
 CMAKE_MINIMUM_REQUIRED(VERSION 2.6.0)
+include (GNUInstallDirs)
 include (${PROJECT_SOURCE_DIR}/build/FindQt5.cmake)
 include (${PROJECT_SOURCE_DIR}/build/UsePkgConfig1.cmake)
 # set(CMAKE_VERBOSE_MAKEFILE ON)
@@ -113,4 +114,5 @@ else (MINGW)
    )
 
    install(TARGETS sf3convert RUNTIME DESTINATION bin)
+   install(FILES sf3convert.1 DESTINATION ${CMAKE_INSTALL_MANDIR}/man1 COMPONENT doc)
 endif (MINGW)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -29,7 +29,7 @@ else (MINGW)
       set(CMAKE_CXX_FLAGS   "${CMAKE_CXX_FLAGS} -g -fPIC -fPIE")
 endif (MINGW)
 
-add_executable(sfconvert
+add_executable(sf3convert
    sfconvert.cpp sfont.cpp xml.cpp
    )
 
@@ -104,7 +104,7 @@ else (MINGW)
       ${VORBIS_INCDIR}
    )
 
-   target_link_libraries(sfconvert
+   target_link_libraries(sf3convert
       ${QT_LIBRARIES}
       ${OGG_LIB}
       ${VORBIS_LIB}
@@ -112,5 +112,5 @@ else (MINGW)
       ${SNDFILE_LIB}
    )
 
-   install(TARGETS sfconvert RUNTIME DESTINATION bin)
+   install(TARGETS sf3convert RUNTIME DESTINATION bin)
 endif (MINGW)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -111,4 +111,6 @@ else (MINGW)
       vorbisenc
       ${SNDFILE_LIB}
    )
+
+   install(TARGETS sfconvert RUNTIME DESTINATION bin)
 endif (MINGW)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -20,10 +20,13 @@ include (${PROJECT_SOURCE_DIR}/build/UsePkgConfig1.cmake)
 set(QT_MIN_VERSION    "5.6")
 set(QT_USE_QTXML         TRUE)
 
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++0x")
+
+# distributions might need to override these
 if (MINGW)
-      set(CMAKE_CXX_FLAGS   "-g -std=c++0x")
+      set(CMAKE_CXX_FLAGS   "${CMAKE_CXX_FLAGS} -g")
 else (MINGW)
-      set(CMAKE_CXX_FLAGS   "-g -std=c++0x -fPIC -fPIE")
+      set(CMAKE_CXX_FLAGS   "${CMAKE_CXX_FLAGS} -g -fPIC -fPIE")
 endif (MINGW)
 
 add_executable(sfconvert

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-### sfconvert
+### sf3convert
 
 Utilities for SoundFont files.
 
@@ -23,7 +23,7 @@ $ make release
 
 This compresses the Fluid sound font from 148 MBytes to 20 MBytes.
 
-    sfconvert -z FluidR3.SF2 mops.sf3
+    sf3convert -z FluidR3.SF2 mops.sf3
 
 **The compressed sound font has the major version number 3. Its non standard
 and can be used only (so far) by [MuseScore](http://musescore.org).**

--- a/sf3convert.1
+++ b/sf3convert.1
@@ -77,6 +77,8 @@ corresponding sample, not based on the beginning of the
 chunk.
 .It
 24-bit mode is disabled.
+.It
+Sample links are removed.
 .El
 .Pp
 Note that this list is

--- a/sf3convert.1
+++ b/sf3convert.1
@@ -1,0 +1,83 @@
+.\" Copyright © 2018 mirabilos <tg@debian.org>
+.\"
+.\" This manual page is provided under the same terms as the tool it describes.
+.Dd March 5, 2018
+.Dt SF3CONVERT 1
+.Os Debian
+.Sh NAME
+.Nm sf3convert
+.Nd SoundFont conversion utility
+.Sh SYNOPSIS
+.Nm
+.Op Fl cdsxz
+.Op Fl a Ar ampl
+.Op Fl p Ar pres
+.Op Fl q Ar qual
+.Ar infile
+.Op Ar outfile
+.Sh DESCRIPTION
+The
+.Nm
+utility converts an SF2 format SoundFont; it can compress it
+into SF3, encode as C for embedding into a binary, or as XML.
+.Pp
+The options are as follows:
+.Bl -tag -width xxx
+.It Fl a Ar ampl
+Set the pre-compression amplification to
+.Ar ampl
+.Pq default \-1.0
+dB.
+.It Fl c
+Output C code.
+.It Fl d
+Dump presets.
+.It Fl p Ar pres
+Append
+.Ar pres
+to the list of presets.
+.It Fl q Ar qual
+Set the Vorbis quality to
+.Ar qual
+.Pq default 0.3 .
+.It Fl s
+Create a small soundfont (one instrument/preset), pan to 0.
+.It Fl x
+Output XML.
+.It Fl z
+Compress the soundfont.
+.El
+.Pp
+The
+.Fl c ,
+.Fl d
+and
+.Fl z
+options are mutually exclusive.
+XML output needs
+.Fl z
+but does not seem to compress.
+.Sh CAVEATS
+Raising the quality to 0.6 might be necessary to avoid artifacts;
+this however increases the size of the generated SF3 by about a third
+(to about fifteen percent of the SF2 size).
+.Pp
+There is no formal specification of the SF3 format yet.
+Differences:
+.Bl -bullet
+.It
+The samples' waveform data is stored using the OGG container
+format with the Vorbis codec.
+(Other codecs supporting the OGG container could be used,
+but the current code uses OGG Vorbis.)
+.It
+Loop start and end are stored based on the beginning of the
+corresponding sample, not based on the beginning of the
+.Li smpl
+chunk.
+.It
+24-bit mode is disabled.
+.El
+.Pp
+Note that this list is
+.Em incomplete .


### PR DESCRIPTION
As packaged already in Debian and/or discussed at: https://github.com/musescore/sftools/issues/12

 * Rename `sfconvert` to `sf3convert`
 * Add a manual page
 * Install the binary and manual page on nōn-MinGW
 * something like global-flags in the main MuseScore repo, in small

Interestingly enough, the Debian buildsystem still appends the necessary flags (`-fPIC` to override `-fPIE`) and `-std=gnu++11` afterwards, so I don’t need to patch the flags further. I just did a test build with this patch (and the https://github.com/musescore/sftools/pull/17 spelling fixes) applied, and it WFM.