### PR TITLE
add an option to build the soundfont reproducibly

### DIFF
--- a/sfconvert.cpp
+++ b/sfconvert.cpp
@@ -43,6 +43,7 @@ static void usage(const char* pname)
       fprintf(stderr, "   -p nn  preset\n");
       fprintf(stderr, "   -d     dump presets\n");
       fprintf(stderr, "   -s     create small sf (one instrument/preset), pan to 0\n");
+      fprintf(stderr, "   -S nn  ogg serial number\n");
       }
 
 //---------------------------------------------------------
@@ -57,6 +58,7 @@ int main(int argc, char* argv[])
       bool compress = false;
       double oggQuality = 0.3;
       double oggAmp = -1.0;
+      qint64 oggSerial = std::numeric_limits<qint64>::max();
 
       QList<int> presets;
 
@@ -65,7 +67,7 @@ int main(int argc, char* argv[])
       fprintf(stderr, "%s: convert sound file\n", argv[0]);
 
       int c;
-      while ((c = getopt(argc, argv, "xcp:dszq:a:")) != EOF) {
+      while ((c = getopt(argc, argv, "xcp:dS:szq:a:")) != EOF) {
             switch(c) {
                   case 'x':
                         xml = true;
@@ -78,6 +80,9 @@ int main(int argc, char* argv[])
                         break;
                   case 'd':
                         dump = true;
+                        break;
+                  case 'S':
+                        oggSerial = atoi(optarg);
                         break;
                   case 's':
                         smallSf = true;
@@ -137,7 +142,7 @@ int main(int argc, char* argv[])
             if (xml)
                   sf.writeXml(&fo);
             else
-                  sf.write(&fo, oggQuality, oggAmp);
+                  sf.write(&fo, oggQuality, oggAmp, oggSerial);
             fo.close();
             }
       qDebug("Soundfont converted in: %d ms", t.elapsed());

--- a/sfont.cpp
+++ b/sfont.cpp
@@ -729,11 +729,12 @@ void SoundFont::write(Xml& xml, Zone* z)
 //   write
 //---------------------------------------------------------
 
-bool SoundFont::write(QFile* f, double oggQuality, double oggAmp)
+bool SoundFont::write(QFile* f, double oggQuality, double oggAmp, qint64 oggSerial)
       {
       file = f;
       _oggQuality = oggQuality;
       _oggAmp = oggAmp;
+      _oggSerial = oggSerial;
       qint64 riffLenPos;
       qint64 listLenPos;
       try {
@@ -1200,7 +1201,7 @@ int SoundFont::writeCompressedSample(Sample* s)
       vorbis_analysis_init(&vd, &vi);
       vorbis_block_init(&vd, &vb);
       srand(time(NULL));
-      ogg_stream_init(&os, rand());
+      ogg_stream_init(&os, _oggSerial == std::numeric_limits<qint64>::max() ? rand() : (int)_oggSerial);
 
       ogg_packet header;
       ogg_packet header_comm;

--- a/sfont.h
+++ b/sfont.h
@@ -179,6 +179,7 @@ class SoundFont {
 
       double _oggQuality;
       double _oggAmp;
+      qint64 _oggSerial;
 
       unsigned readDword();
       int readWord();
@@ -232,7 +233,7 @@ class SoundFont {
       SoundFont(const QString&);
       ~SoundFont();
       bool read();
-      bool write(QFile*, double oggQuality, double oggAmp);
+      bool write(QFile*, double oggQuality, double oggAmp, qint64 oggSerial);
       bool readXml(QFile*);
       bool writeXml(QFile*);
       bool writeCode(QList<int>);


### PR DESCRIPTION
cf. https://wiki.debian.org/ReproducibleBuilds/OggSerialNumbers

`std::numeric_limits<qint64>::max()` is used as flag to keep the previous behaviour of `srand(time(NULL));` and using `rand()` as the stream serial number, as it’s outside of the range of an `int`. Otherwise, the integer argument is used directly as the stream serial number.

I expect most people to use `-S 0` when converting their soundfonts.

With this patch applied, with exact same options (using the new `-S`) and input, the output `.sf3` file is byte-for-byte identical no matter when it is built.