### PR TITLE
build soundfonts reproducibly: use OGG stream serial number zero

### DIFF
--- a/sfont.cpp
+++ b/sfont.cpp
@@ -1199,8 +1199,7 @@ int SoundFont::writeCompressedSample(Sample* s)
       vorbis_comment_init(&vc);
       vorbis_analysis_init(&vd, &vi);
       vorbis_block_init(&vd, &vb);
-      srand(time(NULL));
-      ogg_stream_init(&os, rand());
+      ogg_stream_init(&os, 0);
 
       ogg_packet header;
       ogg_packet header_comm;


### PR DESCRIPTION
Easier than https://github.com/musescore/sftools/pull/19 which adds another option: since we use just one (the same) OGG stream serial number for all samples, simply standardize on using 0 for it.

@lasconic Please apply **either** this one **or** the other one, not both.

Thanks!