### PR TITLE
Improvements and sf3 import

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -38,7 +38,8 @@ if (MINGW)
    target_link_libraries(sf3convert
       ${QT_LIBRARIES}
       vorbis
-      ##vorbisfile
+      vorbisenc
+      vorbisfile
       ogg
       sndfile-1
    )
@@ -52,6 +53,8 @@ if (MINGW)
       ${CROSS}/lib/libsndfile-1.dll
       ${CROSS}/lib/libogg.dll
       ${CROSS}/lib/libvorbis.dll
+      ${CROSS}/lib/libvorbisenc.dll
+      ${CROSS}/lib/libvorbisfile.dll
       ${CROSSQT}/bin/Qt5Core.dll
       ${CROSSQT}/bin/Qt5Xml.dll
       ${CROSSQT}/bin/icuin51.dll
@@ -82,6 +85,28 @@ else (MINGW)
        message("libvorbis not found\n")
    endif (VORBIS_INCDIR)
 
+  ##
+   ## libvorbisenc
+   ##
+
+   PKGCONFIG1 (vorbisenc 1.3.3 VORBISENC_INCDIR VORBISENC_LIBDIR VORBISENC_LIB VORBISENC_CPP)
+   if (VORBISENC_INCDIR)
+       message("libvorbisenc detected ${VORBISENC_INCDIR} ${VORBISENC_LIBDIR} ${VORBISENC_LIB}")
+   else (VORBISENC_INCDIR)
+       message("libvorbisenc not found\n")
+   endif (VORBISENC_INCDIR)
+
+   ##
+   ## libvorbisfile
+   ##
+
+   PKGCONFIG1 (vorbisfile 1.3.3 VORBISFILE_INCDIR VORBISFILE_LIBDIR VORBISFILE_LIB VORBISFILE_CPP)
+   if (VORBISFILE_INCDIR)
+       message("libvorbisfile detected ${VORBISFILE_INCDIR} ${VORBISFILE_LIBDIR} ${VORBISFILE_LIB}")
+   else (VORBISFILE_INCDIR)
+       message("libvorbisfile not found\n")
+   endif (VORBISFILE_INCDIR)
+
 
    ##
    ## libogg
@@ -103,13 +128,16 @@ else (MINGW)
       ${SNDFILE_INCDIR}
       ${OGG_INCDIR}
       ${VORBIS_INCDIR}
+      ${VORBISENC_INCDIR}
+      ${VORBISFILE_INCDIR}
    )
 
    target_link_libraries(sf3convert
       ${QT_LIBRARIES}
       ${OGG_LIB}
       ${VORBIS_LIB}
-      vorbisenc
+      ${VORBISENC_LIB}
+      ${VORBISFILE_LIB}
       ${SNDFILE_LIB}
    )
 

--- a/README.md
+++ b/README.md
@@ -1,9 +1,19 @@
-### sf3convert
+# sf3convert
 
-Utilities for SoundFont files.
+Utilities for converting Soundfont files from version 2 to version 3 and back from version 3 to version 2.
 
-* compress sound font files with ogg vorbis for use with [MuseScore](http://musescore.org)
-* convert to "C" for embedding
+### Sf3 format
+
+The sf3 format stores compressed data (OGG vorbis files) instead of raw data (WAVE) in a soundfont. There is thus a **loss in quality** but the resulting files are lighter and more prone to be **embedded**. This format has been primarily designed and used by [MuseScore](http://musescore.org) and is now supported by other projects:
+
+* [Calf-Fluidsynth](http://calf-studio-gear.org/)
+* [Carla](http://kxstudio.linuxaudio.org/Applications:Carla)
+* [LMMS](https://lmms.io)
+* [Polyphone](https://www.polyphone-soundfonts.com)
+* [Qsynth](https://qsynth.sourceforge.io)
+* [Qtractor](https://qtractor.sourceforge.io)
+
+**The compressed soundfont has the major version number 3. It is non standard and no specifications have been written yet**
 
 
 ### Compilation
@@ -14,6 +24,8 @@ Utilities for SoundFont files.
 * libsdnfile
 * libogg
 * libvorbis
+* libvorbisenc
+* libvorbisfile
 
 ```
 $ make release
@@ -21,14 +33,10 @@ $ make release
 
 ### Usage Example:
 
-This compresses the Fluid sound font from 148 MBytes to 20 MBytes.
+This compresses the Fluid soundfont from 148 MBytes to 20 MBytes.
 
-    sf3convert -z FluidR3.SF2 mops.sf3
+    sf3convert -z FluidR3.SF2 compressed_soundfont.sf3
 
-**The compressed sound font has the major version number 3. Its non standard
-and can be used only (so far) by [MuseScore](http://musescore.org).**
+This uncompresses a soundfont
 
-
-### TODO:
-Stereo samples are compressed as two single streams instead of compressing
-them as stereo ogg vorbis streams. This may be less optimal.
+    sf3convert -y compressed_soundfont.sf3 FluidR3.sf2

--- a/sf3convert.1
+++ b/sf3convert.1
@@ -9,7 +9,7 @@
 .Nd SoundFont conversion utility
 .Sh SYNOPSIS
 .Nm
-.Op Fl cdsxz
+.Op Fl cdsxyz
 .Op Fl a Ar ampl
 .Op Fl p Ar pres
 .Op Fl S Ar number
@@ -20,7 +20,8 @@
 The
 .Nm
 utility converts an SF2 format SoundFont; it can compress it
-into SF3, encode as C for embedding into a binary, or as XML.
+into SF3, uncompress from SF3, encode as C for embedding into a binary,
+or as XML.
 .Pp
 The options are as follows:
 .Bl -tag -width xxx
@@ -49,13 +50,16 @@ as the OGG stream serial number instead of a time-based random one.
 Create a small soundfont (one instrument/preset), pan to 0.
 .It Fl x
 Output XML.
+.It Fl y
+Uncompress the soundfont.
 .It Fl z
 Compress the soundfont.
 .El
 .Pp
 The
 .Fl c ,
-.Fl d
+.Fl d ,
+.Fl y
 and
 .Fl z
 options are mutually exclusive.

--- a/sfconvert.cpp
+++ b/sfconvert.cpp
@@ -26,7 +26,6 @@
 #include <QtCore/QTime>
 #include "sfont.h"
 
-
 //---------------------------------------------------------
 //   usage
 //---------------------------------------------------------
@@ -37,6 +36,7 @@ static void usage(const char* pname)
       fprintf(stderr, "   -z     compress sf\n");
       fprintf(stderr, "   -q qq  ogg quality\n");
       fprintf(stderr, "   -a nn  amplification in dB before ogg compression\n");
+      fprintf(stderr, "   -y     uncompress sf\n");
       fprintf(stderr, "   -x     xml output\n");
       fprintf(stderr, "   -c     c output\n");
       fprintf(stderr, "   -p nn  preset\n");
@@ -55,6 +55,7 @@ int main(int argc, char* argv[])
       bool code = false;
       bool dump = false;
       bool compress = false;
+      bool uncompress = false;
       bool smallSf = false;
       double oggQuality = 0.3;
       double oggAmp = -1.0;
@@ -67,7 +68,7 @@ int main(int argc, char* argv[])
       fprintf(stderr, "%s: convert sound file\n", argv[0]);
 
       int c;
-      while ((c = getopt(argc, argv, "xcp:dS:szq:a:")) != EOF) {
+      while ((c = getopt(argc, argv, "xcp:dS:syzq:a:")) != EOF) {
             switch(c) {
                   case 'x':
                         xml = true;
@@ -86,6 +87,9 @@ int main(int argc, char* argv[])
                         break;
                   case 's':
                         smallSf = true;
+                        break;
+                  case 'y':
+                        uncompress = true;
                         break;
                   case 'z':
                         compress = true;
@@ -113,9 +117,13 @@ int main(int argc, char* argv[])
             usage(pname);
             exit(3);
             }
-      if (!xml && !code && !dump && !compress) {
+      if (!xml && !code && !dump && !compress && !uncompress) {
             usage(pname);
             exit(4);
+            }
+      if (compress && uncompress) {
+            usage(pname)
+            exit(5)
             }
 
       SfTools::SoundFont sf(argv[0]);
@@ -144,10 +152,21 @@ int main(int argc, char* argv[])
             if (xml)
                   sf.writeXml(&fo);
             else
-                  sf.write(&fo, oggQuality, oggAmp, oggSerial);
+                  sf.compress(&fo, oggQuality, oggAmp, oggSerial);
+            fo.close();
+            }
+      else if (uncompress) {
+            QFile fo(argv[1]);
+            if (!fo.open(QIODevice::WriteOnly)) {
+                  fprintf(stderr, "cannot open <%s>\n", argv[2]);
+                  exit(2);
+                  }
+            if (xml)
+                  sf.writeXml(&fo);
+            else
+                  sf.uncompress(&fo);
             fo.close();
             }
       qDebug("Soundfont converted in: %d ms", t.elapsed());
       return 0;
       }
-

--- a/sfconvert.cpp
+++ b/sfconvert.cpp
@@ -26,7 +26,6 @@
 #include <QtCore/QTime>
 #include "sfont.h"
 
-bool smallSf = false;
 
 //---------------------------------------------------------
 //   usage
@@ -56,6 +55,7 @@ int main(int argc, char* argv[])
       bool code = false;
       bool dump = false;
       bool compress = false;
+      bool smallSf = false;
       double oggQuality = 0.3;
       double oggAmp = -1.0;
       qint64 oggSerial = std::numeric_limits<qint64>::max();
@@ -118,7 +118,9 @@ int main(int argc, char* argv[])
             exit(4);
             }
 
-      SoundFont sf(argv[0]);
+      SfTools::SoundFont sf(argv[0]);
+      if (smallSf)
+            sf.smallSf = true;
 
       if (!sf.read()) {
             fprintf(stderr, "sf read error\n");

--- a/sfont.cpp
+++ b/sfont.cpp
@@ -1097,7 +1097,7 @@ int SoundFont::writeCompressedSample(Sample* s)
       ogg_stream_packetin(&os, &header_comm);
       ogg_stream_packetin(&os, &header_code);
 
-      char obuf[1048576]; // 1024 * 1024
+      char* obuf = new char[1048576]; // 1024 * 1024
       char* p = obuf;
 
       for (;;) {
@@ -1178,6 +1178,7 @@ int SoundFont::writeCompressedSample(Sample* s)
       int n = p - obuf;
       write(obuf, n);
 
+      delete [] obuf;
       delete [] ibuffer;
       return n;
       }
@@ -1875,7 +1876,7 @@ bool SoundFont::writeSampleFile(Sample* s, QString name)
             }
       f.seek(samplePos + s->start * sizeof(short));
       int len = s->end - s->start;
-      short buffer[len];
+      short * buffer = new short[len];
       f.read((char*)buffer, len * sizeof(short));
       f.close();
 
@@ -1892,10 +1893,12 @@ bool SoundFont::writeSampleFile(Sample* s, QString name)
       if (sf == 0) {
             fprintf(stderr, "open soundfile <%s> failed: %s\n",
                qPrintable(path), sf_strerror(sf));
+            delete [] buffer;
             return false;
             }
 
       sf_write_short(sf, buffer, len);
+      delete [] buffer;
 
       if (sf_close(sf)) {
             fprintf(stderr, "close soundfile failed\n");
@@ -2048,3 +2051,4 @@ int SoundFont::writeUncompressedSample(Sample* s)
     delete[] ibuffer;
     return length;
 }
+

--- a/sfont.cpp
+++ b/sfont.cpp
@@ -1090,7 +1090,7 @@ int SoundFont::writeCompressedSample(Sample* s)
       ogg_packet header_code;
 
       // Keep a track of the attenuation used before the compression
-      vorbis_comment_add(&vc, QString("AMP=%0\0").arg(_oggAmp).toStdString().c_str());
+      vorbis_comment_add(&vc, QString("AMP=%1\0").arg(_oggAmp).toStdString().c_str());
 
       vorbis_analysis_headerout(&vd, &vc, &header, &header_comm, &header_code);
       ogg_stream_packetin(&os, &header);

--- a/sfont.h
+++ b/sfont.h
@@ -27,6 +27,8 @@
 class Xml;
 class QFile;
 
+namespace SfTools {
+
 //---------------------------------------------------------
 //   sfVersionTag
 //---------------------------------------------------------
@@ -105,14 +107,16 @@ struct Zone {
 //---------------------------------------------------------
 
 struct Preset {
-      char* name         {0};
-      int preset         {0};
-      int bank           {0};
-      int presetBagNdx   {0}; // used only for read
-      int library        {0};
-      int genre          {0};
-      int morphology     {0};
+      char* name;
+      int preset;
+      int bank;
+      int presetBagNdx; // used only for read
+      int library;
+      int genre;
+      int morphology;
       QList<Zone*> zones;
+
+      Preset():name(0), preset(0), bank(0), presetBagNdx(0), library(0), genre(0), morphology(0) {}
       };
 
 //---------------------------------------------------------
@@ -142,6 +146,7 @@ struct Sample {
 
       int origpitch;
       int pitchadj;
+      int sampleLink;
       int sampletype;
 
       Sample();
@@ -207,8 +212,6 @@ class SoundFont {
       void writeChar(char);
       void writeShort(short);
       void write(const char* p, int n);
-      void write(Xml&, Zone*);
-      bool writeSampleFile(Sample*, QString);
       void writeSample(const Sample*);
       void writeStringSection(const char* fourcc, char* s);
       void writePreset(int zoneIdx, const Preset*);
@@ -234,11 +237,23 @@ class SoundFont {
       ~SoundFont();
       bool read();
       bool write(QFile*, double oggQuality, double oggAmp, qint64 oggSerial);
-      bool readXml(QFile*);
-      bool writeXml(QFile*);
       bool writeCode(QList<int>);
       bool writeCode();
       void dumpPresets();
       };
+
+      // Extra option
+      bool smallSf;
+
+#ifndef SFTOOLS_NOXML
+    private:
+      void write(Xml&, Zone*);
+      bool writeSampleFile(Sample*, QString);
+
+    public:
+      bool readXml(QFile*);
+      bool writeXml(QFile*);
+#endif
+}
 #endif
 

--- a/sfont.h
+++ b/sfont.h
@@ -229,14 +229,16 @@ class SoundFont {
       void writeShdr();
 
       int writeCompressedSample(Sample*);
+      int writeUncompressedSample(Sample* s);
       bool writeCSample(Sample*, int);
-      char* readCompressedSample(Sample*);
+      bool write();
 
    public:
       SoundFont(const QString&);
       ~SoundFont();
       bool read();
-      bool write(QFile*, double oggQuality, double oggAmp, qint64 oggSerial);
+      bool compress(QFile* f, double oggQuality, double oggAmp, qint64 oggSerial = rand());
+      bool uncompress(QFile* f);
       bool writeCode(QList<int>);
       bool writeCode();
       void dumpPresets();

--- a/sfont.h
+++ b/sfont.h
@@ -18,8 +18,8 @@
 //  Foundation, Inc., 675 Mass Ave, Cambridge, MA 02139, USA.
 //=============================================================================
 
-#ifndef __SOUNDFONT_H__
-#define __SOUNDFONT_H__
+#ifndef SFONT_H
+#define SFONT_H
 
 #include <QtCore/QString>
 #include <QtCore/QList>
@@ -116,7 +116,7 @@ struct Preset {
       int morphology;
       QList<Zone*> zones;
 
-      Preset():name(0), preset(0), bank(0), presetBagNdx(0), library(0), genre(0), morphology(0) {}
+      Preset():name(nullptr), preset(0), bank(0), presetBagNdx(0), library(0), genre(0), morphology(0) {}
       };
 
 //---------------------------------------------------------
@@ -168,6 +168,8 @@ class SoundFont {
       char* creator;
       char* product;
       char* copyright;
+      char* irom;
+      sfVersionTag iver;
 
       int samplePos;
       int sampleLen;
@@ -182,9 +184,13 @@ class SoundFont {
       QFile* file;
       FILE* f;
 
+      bool _compress;
       double _oggQuality;
       double _oggAmp;
       qint64 _oggSerial;
+
+      // Extra option
+      bool _smallSf;
 
       unsigned readDword();
       int readWord();
@@ -197,7 +203,7 @@ class SoundFont {
       void readSignature(char* signature);
       void skip(int);
       void readSection(const char* fourcc, int len);
-      void readVersion();
+      void readVersion(sfVersionTag* v);
       char* readString(int);
       void readPhdr(int);
       void readBag(int, QList<Zone*>*);
@@ -220,6 +226,7 @@ class SoundFont {
       void writeInstrument(int zoneIdx, const Instrument*);
 
       void writeIfil();
+      void writeIver();
       void writeSmpl();
       void writePhdr();
       void writeBag(const char* fourcc, QList<Zone*>*);
@@ -242,10 +249,6 @@ class SoundFont {
       bool writeCode(QList<int>);
       bool writeCode();
       void dumpPresets();
-      };
-
-      // Extra option
-      bool smallSf;
 
 #ifndef SFTOOLS_NOXML
     private:
@@ -256,6 +259,7 @@ class SoundFont {
       bool readXml(QFile*);
       bool writeXml(QFile*);
 #endif
+};
 }
 #endif
 


### PR DESCRIPTION
Integration improvement (fix #11):
* preprocessor variable to loose the xml and libsnd dependencies
* namespace SfTools
* smallSf now a class variable
* C++11 not needed anymore (struct initialization)
* dynamic declaration of array now ok with visual C++ (fix #10)
* warning and unused variables removed

Bug fix:
* sample links now kept in the soundfont (fix #9)
* the sm24 chunk doesn't stop the program anymore

New feature:
* The conversion tool can now convert back from sf3 to sf2 (fix #22)

Improvement:
* the attenuation is stored in the ogg file so that we can revert it during the extraction